### PR TITLE
style spinner and fix histShipping table spinner

### DIFF
--- a/src/common/CircularProgress.jsx
+++ b/src/common/CircularProgress.jsx
@@ -1,0 +1,15 @@
+import { CircularProgress } from "@mui/material";
+
+export const PackShipProgress = () => {
+  return (
+    <CircularProgress
+      sx={{
+        position: "absolute",
+        top: "calc(50% - 4rem)",
+        left: "calc(50% - 4rem)",
+      }}
+      size="8rem"
+      thickness="8"
+    />
+  );
+};

--- a/src/packing_queue/tables/HistoryTable.jsx
+++ b/src/packing_queue/tables/HistoryTable.jsx
@@ -9,6 +9,7 @@ import EditPackingSlipDialog from "../../edit_packing_slip/EditPackingSlipDialog
 import ConfirmDialog from "../../components/ConfirmDialog";
 import pdfMake from "pdfmake/build/pdfmake";
 import pdfFonts from "pdfmake/build/vfs_fonts";
+import { PackShipProgress } from "../../common/CircularProgress";
 pdfMake.vfs = pdfFonts.pdfMake.vfs;
 
 const useStyle = makeStyles((theme) => ({
@@ -371,7 +372,7 @@ const HistoryTable = ({ sortModel, setSortModel, searchString }) => {
       <DataGrid
         sx={{ border: "none", height: "65vh", minHeight: "20rem" }}
         className={classes.table}
-        rows={filteredRows}
+        rows={isLoading ? [] : filteredRows}
         columns={columns}
         pageSize={10}
         rowsPerPageOptions={[10]}
@@ -384,10 +385,14 @@ const HistoryTable = ({ sortModel, setSortModel, searchString }) => {
         sortModel={sortModel}
         onSortModelChange={setSortModel}
         loading={isLoading}
+        components={{
+          LoadingOverlay: () => <PackShipProgress />,
+        }}
       />
       <ContextMenu
         menuPosition={menuPosition}
-        setMenuPosition={setMenuPosition}>
+        setMenuPosition={setMenuPosition}
+      >
         {historyRowMenuOptions}
       </ContextMenu>
       <EditPackingSlipDialog

--- a/src/packing_queue/tables/PackingQueueTable.jsx
+++ b/src/packing_queue/tables/PackingQueueTable.jsx
@@ -6,6 +6,7 @@ import HelpTooltip from "../../components/HelpTooltip";
 import { createColumnFilters } from "../../utils/TableFilters";
 import { getCheckboxColumn } from "../../components/CheckboxColumn";
 import { API } from "../../services/server";
+import { PackShipProgress } from "../../common/CircularProgress";
 
 const useStyle = makeStyles((theme) => ({
   root: {
@@ -426,10 +427,14 @@ const PackingQueueTable = ({
       <DataGrid
         sx={{ border: "none", height: "65vh", minHeight: "20rem" }}
         className={classes.table}
-        rows={queueData.slice(
-          page * numRowsPerPage,
-          page * numRowsPerPage + numRowsPerPage
-        )}
+        rows={
+          isLoading
+            ? []
+            : queueData.slice(
+                page * numRowsPerPage,
+                page * numRowsPerPage + numRowsPerPage
+              )
+        }
         columns={columns}
         pageSize={numRowsPerPage}
         rowsPerPageOptions={[numRowsPerPage]}
@@ -449,6 +454,7 @@ const PackingQueueTable = ({
           );
         }}
         components={{
+          LoadingOverlay: () => <PackShipProgress />,
           Footer: () =>
             selectionOrderIds.length > 0 ? (
               <Grid container item alignItems="center" spacing={2}>

--- a/src/router/router.jsx
+++ b/src/router/router.jsx
@@ -13,7 +13,7 @@ import { themes } from "../themes/base";
 import GoogleButton from "react-google-button";
 import axios from "axios";
 import { LoginSuccess } from "../components/LoginSuccess";
-import { CircularProgress } from "@mui/material";
+import { PackShipProgress } from "../common/CircularProgress";
 
 export const ROUTE_PACKING_SLIP = "/packing-slips";
 export const ROUTE_SHIPMENTS = "/shipments";
@@ -100,7 +100,7 @@ const Router = () => {
   };
 
   return loading ? (
-    <CircularProgress sx={{ position: "absolute", top: "calc(50% - 4rem)", left: "calc(50% - 4rem)" }} size='8rem' thickness='8' />
+    <PackShipProgress />
   ) : (
     <Routes>
       <Route path="" element={<Navigate to="/login" />} />

--- a/src/shipping_queue/ShippingQueue.jsx
+++ b/src/shipping_queue/ShippingQueue.jsx
@@ -282,7 +282,7 @@ const ShippingQueue = () => {
                 histTotalCount={histTotalCount}
                 orderNumber={orderNumber}
                 partNumber={partNumber}
-                loading={historyLoading}
+                historyLoading={historyLoading}
               />
             }
           />

--- a/src/shipping_queue/tables/ShippingHistoryTable.jsx
+++ b/src/shipping_queue/tables/ShippingHistoryTable.jsx
@@ -9,6 +9,7 @@ import ConfirmDialog from "../../components/ConfirmDialog";
 import { isShippingInfoValid } from "../../utils/Validators";
 import { API } from "../../services/server";
 import { getSortFromModel } from "../utils/sortModelFunctions";
+import { PackShipProgress } from "../../common/CircularProgress";
 
 const useStyle = makeStyles((theme) => ({
   root: {
@@ -310,7 +311,8 @@ const ShippingHistoryTable = ({
       onClick={() => {
         setIsEditShipmentOpen(true);
         setIsEditShipmentViewOnly(true);
-      }}>
+      }}
+    >
       View
     </MenuItem>,
     // <MenuItem key="download-menu-item">Download</MenuItem>,
@@ -319,7 +321,8 @@ const ShippingHistoryTable = ({
       onClick={() => {
         setIsEditShipmentOpen(true);
         setIsEditShipmentViewOnly(false);
-      }}>
+      }}
+    >
       Edit
     </MenuItem>,
     <MenuItem
@@ -327,7 +330,8 @@ const ShippingHistoryTable = ({
       onClick={() => {
         setHistoryMenuPosition(null);
         setConfirmShippingDeleteDialogOpen(true);
-      }}>
+      }}
+    >
       Delete
     </MenuItem>,
   ];
@@ -341,7 +345,7 @@ const ShippingHistoryTable = ({
         sx={{ border: "none", height: "65vh", minHeight: "20rem" }}
         className={classes.table}
         disableSelectionOnClick={true}
-        rows={filteredShippingHist}
+        rows={isLoading || historyLoading ? [] : filteredShippingHist}
         rowHeight={65}
         columns={columns}
         pageSize={histResultsPerPage}
@@ -363,11 +367,15 @@ const ShippingHistoryTable = ({
           setIsLoading(false);
         }}
         loading={isLoading || historyLoading}
+        components={{
+          LoadingOverlay: () => <PackShipProgress />,
+        }}
       />
 
       <ContextMenu
         menuPosition={historyMenuPosition}
-        setMenuPosition={setHistoryMenuPosition}>
+        setMenuPosition={setHistoryMenuPosition}
+      >
         {historyRowMenuOptions}
       </ContextMenu>
 
@@ -432,7 +440,8 @@ const ShippingHistoryTable = ({
         setOpen={setConfirmShippingDeleteDialogOpen}
         onConfirm={() => {
           API.deleteShipment(clickedHistShipment._id).then(() => reloadData());
-        }}>
+        }}
+      >
         <Typography sx={{ fontWeight: 900 }}>
           {clickedHistShipment?.shipmentId}
         </Typography>

--- a/src/shipping_queue/tables/ShippingQueueTable.jsx
+++ b/src/shipping_queue/tables/ShippingQueueTable.jsx
@@ -8,6 +8,7 @@ import { getCheckboxColumn } from "../../components/CheckboxColumn";
 import ShipQueuePackSlipDrowdown from "./ShipQueuePackSlipDropdown";
 import { API } from "../../services/server";
 import CreateShipmentDialog from "../../create_shipment/CreateShipmentDialog";
+import { PackShipProgress } from "../../common/CircularProgress";
 
 const useStyle = makeStyles((theme) => ({
   root: {
@@ -332,10 +333,14 @@ const ShippingQueueTable = ({
           tmpData[tmpIndex].open = !tmpData || !tmpData[tmpIndex].open;
           setQueueData(tmpData);
         }}
-        rows={queueData.slice(
-          page * numRowsPerPage,
-          page * numRowsPerPage + numRowsPerPage
-        )}
+        rows={
+          isLoading
+            ? []
+            : queueData.slice(
+                page * numRowsPerPage,
+                page * numRowsPerPage + numRowsPerPage
+              )
+        }
         rowHeight={65}
         columns={columns}
         pageSize={numRowsPerPage}
@@ -355,6 +360,7 @@ const ShippingQueueTable = ({
           setQueueData(sortDataByModel(model, tableData));
         }}
         components={{
+          LoadingOverlay: () => <PackShipProgress />,
           Footer: () =>
             selectedOrderIds.length > 0 ? (
               <Grid container alignItems="center" spacing={2}>


### PR DESCRIPTION
closes #30 

@jarrilla I think I fixed the shipment history loading. The issue was just a variable named incorrectly. Also, the way the issue was worded, it made it sound like you wanted the grey overlay only to stop the user interaction with the table. I made it so the rows will no longer show the stale data while loading - so there can be no interaction. I am using the loading spinner you made previously, just to be consistent. Take it for a spin and let me know what you think.