### PR TITLE
use _id for choosing edit packing slip

### DIFF
--- a/src/components/EditTableDropdown.jsx
+++ b/src/components/EditTableDropdown.jsx
@@ -7,6 +7,7 @@ const EditTableDropdown = ({
   value,
   valueKey,
   menuKeyValue,
+  menuOptionFn,
 }) => {
   return (
     <Select
@@ -28,7 +29,7 @@ const EditTableDropdown = ({
             key={`${e[valueKey]}-${e[menuKeyValue]}`}
             value={e[valueKey]}
           >
-            {e[valueKey]}
+            {menuOptionFn(e)}
           </MenuItem>
         );
       })}

--- a/src/edit_packing_slip/components/EditPackingSlipTable.jsx
+++ b/src/edit_packing_slip/components/EditPackingSlipTable.jsx
@@ -23,7 +23,10 @@ const EditPackingSlipTable = ({
             )}
             value={params.row}
             onChange={onNewPartRowChange}
-            valueKey="partNumber"
+            valueKey="_id"
+            menuOptionFn={(e) =>
+              `${e.partNumber} - Rev ${e.partRev} (Batch ${e.batch})`
+            }
           />
         );
       } else {

--- a/src/packing_queue/tables/HistoryTable.jsx
+++ b/src/packing_queue/tables/HistoryTable.jsx
@@ -178,9 +178,7 @@ const HistoryTable = ({ sortModel, setSortModel, searchString }) => {
   const onNewPartRowChange = useCallback(
     (oldVal, newVal) => {
       const itemIndex = selectedRow?.items?.findIndex(
-        (e) =>
-          e.item.orderNumber === oldVal.orderNumber &&
-          e.item.partNumber === oldVal.partNumber
+        (e) => e.item._id === oldVal._id
       );
       let updatedPackingSlip = {
         ...selectedRow,
@@ -387,7 +385,8 @@ const HistoryTable = ({ sortModel, setSortModel, searchString }) => {
       />
       <ContextMenu
         menuPosition={menuPosition}
-        setMenuPosition={setMenuPosition}>
+        setMenuPosition={setMenuPosition}
+      >
         {historyRowMenuOptions}
       </ContextMenu>
       <EditPackingSlipDialog

--- a/src/shipping_queue/EditShipmentDialog.jsx
+++ b/src/shipping_queue/EditShipmentDialog.jsx
@@ -36,6 +36,7 @@ const EditShipmentTableDialog = ({
           onChange={onNewRowChange}
           value={params.row}
           valueKey="packingSlipId"
+          menuOptionFn={(e) => `${e.packingSlipId}`}
         />
       );
     } else if (!params.id.includes("add-row-id")) {
@@ -71,7 +72,9 @@ const EditShipmentTableDialog = ({
         }`}
         onClose={onClose}
         onSubmit={onSubmit}
-        actions={viewOnly ? <DialogActions sx={{height: "43.5px"}}/> : undefined}
+        actions={
+          viewOnly ? <DialogActions sx={{ height: "43.5px" }} /> : undefined
+        }
       >
         <PackShipEditableTable
           tableData={shipment?.manifest?.map((e) => {


### PR DESCRIPTION
closes #31 


I made the menu option appear like https://github.com/conturo-prototyping/pack-ship-client/issues/31#issuecomment-1158404225 and made it so the id is used when an option is selected. 