### PR TITLE
Extra row in view mode on dialogs

### DIFF
--- a/src/components/EdittableTable.jsx
+++ b/src/components/EdittableTable.jsx
@@ -69,14 +69,16 @@ const PackShipEditableTable = ({
   }, [columns, onAdd, onDelete, viewOnly]);
 
   const newRows = React.useMemo(() => {
-    // Add row for the ability to add a new row
-    const newRows = [...tableData];
-    newRows.push({
-      id: addRowId,
-    });
-    return newRows;
-    // eslint-disable-next-line
-  }, [tableData]);
+    // Add row for the ability to add a new row when not in viewONly
+    return viewOnly
+      ? tableData
+      : [
+          ...tableData,
+          {
+            id: addRowId,
+          },
+        ];
+  }, [tableData, viewOnly]);
 
   const localPageSize = useMemo(() => {
     return viewOnly ? pageSize : newRows.length;


### PR DESCRIPTION
We were adding an extra row into the table when in view mode. This extra row is only needed in edit mode.

Closes #37 