### PR TITLE
Shipping address reset

### DIFF
--- a/src/create_shipment/CreateShipmentDialog.jsx
+++ b/src/create_shipment/CreateShipmentDialog.jsx
@@ -114,6 +114,10 @@ const CreateShipmentDialog = ({
   const onBackShippingAddress = () => {
     setCurrentState(ShippingDialogStates.SelectMethodPage);
     setCustomerName("");
+    setShippingInfo({
+      ...shippingInfo,
+      specialShippingAddress: undefined,
+    });
     onResetClick();
   };
 


### PR DESCRIPTION
This fixes an issue where the shipping address would not reset upon hitting the back button on the pickup or dropoff options. Changed it to be this way to be consistent with the carrier field. 