### PR TITLE
Sorting by shipment label in shipment ps 35

### DIFF
--- a/src/shipping_queue/tables/ShippingQueueTable.jsx
+++ b/src/shipping_queue/tables/ShippingQueueTable.jsx
@@ -109,7 +109,7 @@ const ShippingQueueTable = ({
               queueTableData.push({
                 id: e._id,
                 orderNumber: e.orderNumber,
-                label: e.label,
+                label: e?.label,
                 customer: e.customer,
                 items: e.items,
                 destination: e.destination,


### PR DESCRIPTION
I had a hard time reproducing this, so I am not sure if this is the correct fix. I think it may be coming from an improper conversion from the old packingSlipID to the new label field. @jarrilla if this doesn't fix it, could you send me a screenshot of the error you see along with example data for it? With the current debugging reset and the migrate, I wasn't able to fully test this without more specifics about what your data looks like. 