### PR TITLE
Fixed issue with PDFs not loading in production

### DIFF
--- a/src/packing_slip/components/PDFPreview.jsx
+++ b/src/packing_slip/components/PDFPreview.jsx
@@ -1,7 +1,10 @@
 import React from "react";
-import { Document, Page } from "react-pdf/dist/esm/entry.webpack5";
+import { Document, Page, pdfjs } from "react-pdf/dist/esm/entry.webpack5";
 import "react-pdf/dist/esm/Page/AnnotationLayer.css";
 import withStyledDismiss from "./DismissablePreview";
+
+const url = `//cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = url;
 
 const PDFPreview = ({
   url,


### PR DESCRIPTION
Fixed issue with viewing PDFs on optimized production builds. 

Issue can be found here with solution made: 
https://github.com/wojtekmaj/react-pdf/issues/782